### PR TITLE
clean up on build-publish.yml

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,5 +1,4 @@
-name: Build and push images to GitHub Container Registry
-
+name: Build and publish images to ghcr.io
 on:
   push:
     branches: [ "main" ]
@@ -8,7 +7,7 @@ permissions:
   packages: write
 
 jobs:
-  build-and-push:
+  build-and-publish:
     runs-on: ubuntu-latest
     steps:
 
@@ -21,13 +20,13 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     # Build images
-    - name: Build app images - frontend and backend
+    - name: Build images
       run: |
         docker build ./sinuweb_hdl_cms -t ghcr.io/solomon-islands-national-university/website-wagtailbackend:latest
-        docker build -f ./sinuweb-frontend/.docker/prod/Dockerfile ./sinuweb-frontend -t ghcr.io/solomon-islands-national-university/website-nextjs:latest
+        docker build -f ./sinuweb-frontend/.docker/prod/Dockerfile ./sinuweb-frontend -t ghcr.io/solomon-islands-national-university/website-nextjsfrontend:latest
 
     # Login to ghcr.io
-    - name: Log in to GitHub Container Registry (ghcr.io)
+    - name: Login to ghcr.io
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -35,7 +34,7 @@ jobs:
         password: ${{ secrets.GH_PAT }}
 
     # push images to ghcr.io
-    - name: Push images to ghcr.io
+    - name: publish images
       run: |
         docker push ghcr.io/solomon-islands-national-university/website-wagtailbackend:latest
-        docker push ghcr.io/solomon-islands-national-university/website-nextjs:latest
+        docker push ghcr.io/solomon-islands-national-university/website-nextjsfrontend:latest


### PR DESCRIPTION
Renamed build.yml to build-publish.yml since this workflow builds and pushes the frontend and backend images to ghcr.io.